### PR TITLE
Make dependency on magento/framework more open

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "AFL-3.0"
   ],
   "require": {
-    "magento/framework": "100.0.*"
+    "magento/framework": "^100.0.0"
   },
   "type": "magento2-language",
   "autoload": {


### PR DESCRIPTION
Hi guys

Big thank you for the translation pack, awesome work!

This pull request opens up the composer dependency on magento/framework version.
Otherwise you can't use this module in combination with Magento 2.1 (rc versions at the moment).

The [caret](https://getcomposer.org/doc/articles/versions.md#caret) type is the preferred way to set up version constraints, because right now your constraint only allowed changes on the third number. This fix will also allow the second number to change (which happens in Magento 2.1: 100.1.xxx).
Backwards incompatible changes happen when the first number changes, so as long as the magento/framework versions follow [semver](http://semver.org/), everything should work out fine.
